### PR TITLE
Doing bare reverse proxy with label selector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,12 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/gorilla/websocket v1.4.0
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73 // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
-	k8s.io/api v0.19.0-beta.2
 	k8s.io/apimachinery v0.19.0-beta.2
 	k8s.io/client-go v0.19.0-beta.2
 	k8s.io/utils v0.0.0-20200912215256-4140de9c8800 // indirect

--- a/main.go
+++ b/main.go
@@ -33,9 +33,10 @@ func main() {
 	var mgr ctrl.Manager
 
 	fs := flag.NewFlagSet("filter", flag.ExitOnError)
-	listeningPort := fs.Uint("listening-port", 9001, "HTTP port the proxy listens to")
-	k8sControlPlaneUrl := fs.String("k8s-control-plane-url", "https://kubernetes.default.svc", "Kubernetes control plane URL")
-	capsuleUserGroup := fs.String("capsule-user-group", "clastix.capsule.io", "The Capsule User Group eligible to create Namespace for Tenant resources")
+	listeningPort := fs.Uint("listening-port", 9001, "HTTP port the proxy listens to (default: 9001)")
+	k8sControlPlaneUrl := fs.String("k8s-control-plane-url", "https://kubernetes.default.svc", "Kubernetes control plane URL (default: https://kubernetes.default.svc)")
+	capsuleUserGroup := fs.String("capsule-user-group", "clastix.capsule.io", "The Capsule User Group eligible to create Namespace for Tenant resources (default: clastix.capsule.io)")
+	usernameClaimField := fs.String("oidc-username-claim", "preferred_username", "The OIDC field name used to identify the user (default: preferred_username)")
 	err = fs.Parse(os.Args[1:])
 
 	opts := zap.Options{}
@@ -48,9 +49,10 @@ func main() {
 	}
 
 	log.Info("---")
-	log.Info(fmt.Sprintf("Manager will listen to port %d", *listeningPort))
+	log.Info(fmt.Sprintf("Manager listening on port %d", *listeningPort))
 	log.Info(fmt.Sprintf("Connecting to the Kubernete API Server listening on %s", *k8sControlPlaneUrl))
 	log.Info(fmt.Sprintf("The selected Capsule User Group is %s", *capsuleUserGroup))
+	log.Info(fmt.Sprintf("The OIDC username filed  %s", *usernameClaimField))
 	log.Info("---")
 
 	log.Info("Creating the manager")
@@ -65,7 +67,7 @@ func main() {
 
 	log.Info("Creating the Field Indexer")
 	ow := tenant.OwnerReference{}
-	err = mgr.GetFieldIndexer().IndexField(context.TODO(), ow.Object(), ow.Field(), ow.Func())
+	err = mgr.GetFieldIndexer().IndexField(context.Background(), ow.Object(), ow.Field(), ow.Func())
 	if err != nil {
 		log.Error(err, "cannot create new Field Indexer")
 		os.Exit(1)
@@ -73,7 +75,7 @@ func main() {
 
 	var r manager.Runnable
 	log.Info("Creating the NamespaceFilter runner")
-	r, err = webserver.NewKubeFilter(*listeningPort, *k8sControlPlaneUrl, *capsuleUserGroup, ctrl.GetConfigOrDie())
+	r, err = webserver.NewKubeFilter(*listeningPort, *k8sControlPlaneUrl, *capsuleUserGroup, *usernameClaimField, ctrl.GetConfigOrDie())
 	if err != nil {
 		log.Error(err, "cannot create NamespaceFilter runner")
 		os.Exit(1)


### PR DESCRIPTION
Closes #1.

The `labelSelector` query string parameter is so much powerful and we don't need to mimic at all the API Server with websockets, table output, or listing.

With this feature, we just need to decorate the HTTP request with the additional selector and here we go: neat and clean solution!

@bsctl need help here with documentation.