### PR TITLE
change namespaces filtering criteria to fix #24

### DIFF
--- a/internal/request/http.go
+++ b/internal/request/http.go
@@ -26,7 +26,7 @@ func NewHttp(request *h.Request, usernameClaimField string) Request {
 }
 
 func (h http) IsNamespaceListing() (ok bool) {
-	ok = h.RequestURI == "/api/v1/namespaces"
+	ok = h.URL.Path == "/api/v1/namespaces"
 	ok = (h.Method == "GET" || h.isWatchEndpoint()) && ok
 	return
 }


### PR DESCRIPTION
Changed the namespace filtering criteria by checking the URL instead of URI in the user's requests. @prometherion, please review or propose another solution to fix #24 