### PR TITLE
fix(internal/request): add missing impersonate groups for serviceaccounts

### DIFF
--- a/internal/request/http.go
+++ b/internal/request/http.go
@@ -10,6 +10,7 @@ import (
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -97,6 +98,15 @@ func (h http) GetUserAndGroups() (username string, groups []string, err error) {
 		defer func() {
 			username = impersonateUser
 			groups = nil
+
+			// If the user is of a service account, replicate the work of the built-in service account token authenticator
+			// by appending the expected service account groups:
+			// - system:serviceaccounts:<namespace>
+			// - system:serviceaccounts
+			if namespace, _, err := serviceaccount.SplitUsername(username); err == nil {
+				groups = append(groups, serviceaccount.AllServiceAccountsGroup)
+				groups = append(groups, fmt.Sprintf("%s%s", serviceaccount.ServiceAccountGroupPrefix, namespace))
+			}
 		}()
 	}
 


### PR DESCRIPTION
**What it does**

This PR adds missing impersonate groups for `ServiceAccount`s.

**Context**

When clients request to impersonate user, the group impersonation should be done only when also clients request explicitely to impersonate group.

**The problem**

Nevertheless, an exception should be considered for service accounts.
With service account built-in authenticator, requests made with service account token are authenticated as:
- user name: `system:serviceaccount:<namespace>:<serviceaccount_name>`
- groups:
  - `system:serviceaccounts`
  - `system:serviceaccounts:<namespace>`
  - `system:authenticated` (included for all authenticated users)

**The solution**

This patch considers the case of service accounts adding the mentioned groups to the list of impersonate groups, when requests try to impersonate a service account's user.

**Related issue**

Fixes #349

**Additional info**

More details in the official documentation about service account authenticator [1] and user impersonation [2].

1. https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens
2. https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation
---