### PR TITLE
feat(controller): add impersonation group filter options

### DIFF
--- a/internal/options/listener.go
+++ b/internal/options/listener.go
@@ -6,6 +6,7 @@ package options
 import (
 	"net/http"
 	"net/url"
+	"regexp"
 
 	"github.com/projectcapsule/capsule-proxy/internal/request"
 )
@@ -14,6 +15,8 @@ type ListenerOpts interface {
 	AuthTypes() []request.AuthType
 	KubernetesControlPlaneURL() *url.URL
 	IgnoredGroupNames() []string
+	IgnoredImpersonationsGroups() []string
+	ImpersonationGroupsRegexp() *regexp.Regexp
 	PreferredUsernameClaim() string
 	ReverseProxyTransport() (*http.Transport, error)
 	BearerToken() string

--- a/internal/request/impersonation.go
+++ b/internal/request/impersonation.go
@@ -5,6 +5,7 @@ package request
 
 import (
 	nethttp "net/http"
+	"regexp"
 	"strings"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -25,6 +26,42 @@ func GetImpersonatingUser(request *nethttp.Request) string {
 	return request.Header.Get(authenticationv1.ImpersonateUserHeader)
 }
 
-func GetImpersonatingGroups(request *nethttp.Request) []string {
-	return request.Header.Values(authenticationv1.ImpersonateGroupHeader)
+func GetImpersonatingGroups(request *nethttp.Request, ignoreImpersonationGroups []string, impersonationGroupsRegexp *regexp.Regexp) []string {
+	groups := request.Header.Values(authenticationv1.ImpersonateGroupHeader)
+	if len(groups) > 0 {
+		if impersonationGroupsRegexp != nil {
+			groups = filterGroups(groups, impersonationGroupsRegexp)
+		}
+
+		if len(ignoreImpersonationGroups) > 0 {
+			groups = ignoreGroups(groups, regexp.MustCompile(strings.Join(ignoreImpersonationGroups, "|")))
+		}
+	}
+
+	return groups
+}
+
+func filterGroups(groups []string, impersonationGroupsRegexp *regexp.Regexp) []string {
+	filteredGroups := []string{}
+
+	for _, group := range groups {
+		if impersonationGroupsRegexp.MatchString(group) {
+			filteredGroups = append(filteredGroups, group)
+		}
+	}
+
+	return filteredGroups
+}
+
+func ignoreGroups(groups []string, ignoredGroupsRegexp *regexp.Regexp) []string {
+	ignoredGroups := []string{}
+
+	for _, group := range groups {
+		if !ignoredGroupsRegexp.MatchString(group) {
+			// If the group does NOT match the regex, include it in the filtered list
+			ignoredGroups = append(ignoredGroups, group)
+		}
+	}
+
+	return ignoredGroups
 }

--- a/internal/webserver/middleware/user_in_group.go
+++ b/internal/webserver/middleware/user_in_group.go
@@ -19,7 +19,7 @@ func CheckUserInIgnoredGroupMiddleware(client client.Writer, log logr.Logger, cl
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			if ignoredUserGroups.Len() > 0 {
-				user, groups, err := req.NewHTTP(request, authTypes, claim, client).GetUserAndGroups()
+				user, groups, err := req.NewHTTP(request, authTypes, claim, client, nil, nil).GetUserAndGroups()
 				if err != nil {
 					log.Error(err, "Cannot retrieve username and group from request")
 				}
@@ -42,7 +42,7 @@ func CheckUserInIgnoredGroupMiddleware(client client.Writer, log logr.Logger, cl
 func CheckUserInCapsuleGroupMiddleware(client client.Writer, log logr.Logger, claim string, authTypes []req.AuthType, impersonate func(http.ResponseWriter, *http.Request)) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-			_, groups, err := req.NewHTTP(request, authTypes, claim, client).GetUserAndGroups()
+			_, groups, err := req.NewHTTP(request, authTypes, claim, client, nil, nil).GetUserAndGroups()
 			if err != nil {
 				log.Error(err, "Cannot retrieve username and group from request")
 			}


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule-proxy/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

Adds options to filter groups that will be impersonated. We experienced based on the correction in (https://github.com/projectcapsule/capsule-proxy/pull/331) that the performance greatly decreased because of the amount of groups we have in the claim and the resulting requests to the API server.

With these options the amount of groups which are considered for impersonated can be decreased resulting in less requests.

@MaxFedotov wdyt? Do you also experience performance issues? did you also change the qos and burst of the kube client?

Maybe we can do additional adjustments to improve the performance. But i can't think of anything else to decrease the requests made to the API to request impersonation.  Batching all the groups would help, however there's nothing on the kubernetes API which would offer such a function.

Maybe adding FlowSchemes and APIPriority might also help. 
