### PR TITLE
fix(controller): correct client overwrites

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,8 +223,10 @@ First match is used and can be specified multiple times as comma separated value
 
 	var clientOverride client.Reader
 
-	if !disableCaching {
+	if disableCaching {
 		clientOverride = mgr.GetAPIReader()
+	} else {
+		clientOverride = mgr.GetClient()
 	}
 
 	r, err = webserver.NewKubeFilter(listenerOpts, serverOpts, gates, rbReflector, clientOverride, mgr.GetClient())


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule-proxy/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

Fixes #390

If I understand correctly, the client needs to swaped. since `GetClient()`:

```
// GetClient returns a client configured with the Config. This client may
// not be a fully "direct" client -- it may read from a cache, for
// instance.  See Options.NewClient for more information on how the default
// implementation works.
```