### PR TITLE
chore: Update kube-webhook-certgen image

### DIFF
--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -110,9 +110,9 @@ If you only need to make minor customizations, you can specify them on the comma
 | jobs.affinity | object | `{}` | Set affinity rules |
 | jobs.annotations | object | `{}` | Annotations to add to the certgen job. |
 | jobs.certs.pullPolicy | string | `"IfNotPresent"` | Set the image pull policy of the post install certgen job |
-| jobs.certs.registry | string | `"docker.io"` | Set the image repository of the post install certgen job |
-| jobs.certs.repository | string | `"jettech/kube-webhook-certgen"` | Set the image repository of the post install certgen job |
-| jobs.certs.tag | string | `"v1.3.0"` | Set the image tag of the post install certgen job |
+| jobs.certs.registry | string | `"registry.k8s.io"` | Set the image repository of the post install certgen job |
+| jobs.certs.repository | string | `"ingress-nginx/kube-webhook-certgen"` | Set the image repository of the post install certgen job |
+| jobs.certs.tag | string | `"v1.4.3"` | Set the image tag of the post install certgen job |
 | jobs.nodeSelector | object | `{}` | Set the node selector |
 | jobs.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the job pods. |
 | jobs.priorityClassName | string | `""` | Set a pod priorityClassName |

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -178,13 +178,13 @@ options:
 jobs:
   certs:
     # -- Set the image repository of the post install certgen job
-    registry: docker.io
+    registry: registry.k8s.io
     # -- Set the image repository of the post install certgen job
-    repository: jettech/kube-webhook-certgen
+    repository: ingress-nginx/kube-webhook-certgen
     # -- Set the image pull policy of the post install certgen job
     pullPolicy: IfNotPresent
     # -- Set the image tag of the post install certgen job
-    tag: "v1.3.0"
+    tag: "v1.4.3"
   # -- Annotations to add to the certgen job.
   annotations: {}
   # -- Set the restartPolicy


### PR DESCRIPTION
Using kube-webhook-certgen from nginx-ingress repo looks more healthy than jettech repo:

https://github.com/kubernetes/ingress-nginx/tree/main/images/kube-webhook-certgen