### PR TITLE
fix: allow wildcards on certificate generation

### DIFF
--- a/charts/capsule-proxy/templates/certmanager.yaml
+++ b/charts/capsule-proxy/templates/certmanager.yaml
@@ -42,11 +42,11 @@ spec:
   dnsNames:
   {{- if .Values.ingress.enabled -}}
     {{- range $hosts := .Values.ingress.hosts }}
-  - {{ $hosts.host }}
+  - {{ $hosts.host | quote }}
     {{- end }}
   {{- end }}
   {{- range $dns := .Values.certManager.certificate.dnsNames }}
-  - {{ $dns }}
+  - {{ $dns | quote }}
   {{- end }}
   {{- if $.Values.certManager.certificate.includeInternalServiceNames }}
   - {{ include "capsule-proxy.fullname" . }}


### PR DESCRIPTION
Fix #523 
