### PR TITLE
feat: add support for bearer tokens in websocket protocols

### DIFF
--- a/internal/request/http.go
+++ b/internal/request/http.go
@@ -132,6 +132,7 @@ func (h http) processBearerToken() (username string, groups []string, err error)
 	if err != nil {
 		return "", nil, err
 	}
+
 	tr := &authenticationv1.TokenReview{
 		Spec: authenticationv1.TokenReviewSpec{
 			Token: token,

--- a/internal/request/http_test.go
+++ b/internal/request/http_test.go
@@ -171,6 +171,7 @@ func Test_http_GetUserAndGroups(t *testing.T) {
 				usernameClaimField: "",
 				client: testClient(func(ctx context.Context, obj client.Object) error {
 					tr := obj.(*authenticationv1.TokenReview)
+
 					if tr.Spec.Token == "asdf" {
 						tr.Status.Authenticated = true
 
@@ -198,8 +199,9 @@ func Test_http_GetUserAndGroups(t *testing.T) {
 				usernameClaimField: "",
 				client: testClient(func(ctx context.Context, obj client.Object) error {
 					tr := obj.(*authenticationv1.TokenReview)
-					if tr.Spec.Token == "asdf" {
+					if tr.Spec.Token == "fdsa" {
 						tr.Status.Authenticated = true
+
 						return nil
 					}
 


### PR DESCRIPTION
This is a simple change that enables us to extract the JWT from the WebSocket protocols as defined here https://github.com/kubernetes/kubernetes/pull/47740. This satisfies #499.

Let me know if any changes are needed.

Thank you!