### PR TITLE
fix: support service account bound token expiration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/go-logr/logr v1.4.2
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/internal/options/kube.go
+++ b/internal/options/kube.go
@@ -64,6 +64,10 @@ func (k kubeOpts) BearerToken() string {
 	return k.config.BearerToken
 }
 
+func (k kubeOpts) BearerTokenFile() string {
+	return k.config.BearerTokenFile
+}
+
 func (k kubeOpts) KubernetesControlPlaneURL() *url.URL {
 	return &k.url
 }

--- a/internal/options/listener.go
+++ b/internal/options/listener.go
@@ -19,6 +19,7 @@ type ListenerOpts interface {
 	ImpersonationGroupsRegexp() *regexp.Regexp
 	PreferredUsernameClaim() string
 	ReverseProxyTransport() (*http.Transport, error)
+	BearerTokenFile() string
 	BearerToken() string
 	SkipImpersonationReview() bool
 }


### PR DESCRIPTION
Fixes #566 

From kubernetes 1.30 kubelet takes care of renewing tokens for service accounts inside the projected volumes. This PR make capsule-proxy to reload the token when required.