### PR TITLE
chore(helm): removing hard coded version values

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 0.5.0
+appVersion: 0.0.0
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.5.4
+version: 0.0.0
 home: https://github.com/projectcapsule/capsule-proxy
 icon: https://github.com/projectcapsule/capsule/raw/main/assets/logo/capsule_small.png
 keywords:


### PR DESCRIPTION
When publishing a Capsule Proxy release, Chart and Image versions are inflected automatically from the git tag: having fixed values in the Helm Chart is useless.

https://github.com/projectcapsule/capsule-proxy/blob/b2097d56dc8f03b727447280986c4df1a58b5cab/.github/workflows/helm-publish.yml#L62-L63