### PR TITLE
feat: proxy webhooks

### DIFF
--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -104,7 +104,7 @@ If you only need to make minor customizations, you can specify them on the comma
 | global.jobs.certs.topologySpreadConstraints | list | `[]` | Set Topology Spread Constraints |
 | global.jobs.certs.ttlSecondsAfterFinished | int | `60` | Sets the ttl in seconds after a finished certgen job is deleted. Set to -1 to never delete. |
 | global.jobs.kubectl.affinity | object | `{}` | Set affinity rules |
-| global.jobs.kubectl.annotations | object | `{"helm.sh/hook-delete-policy":"before-hook-creation,hook-succeeded"}` | Annotations to add to the certgen job. |
+| global.jobs.kubectl.annotations | object | `{}` | Annotations |
 | global.jobs.kubectl.image.pullPolicy | string | `"IfNotPresent"` | Set the image pull policy of the helm chart job |
 | global.jobs.kubectl.image.registry | string | `"docker.io"` | Set the image repository of the helm chart job |
 | global.jobs.kubectl.image.repository | string | `"clastix/kubectl"` | Set the image repository of the helm chart job |
@@ -184,7 +184,9 @@ If you only need to make minor customizations, you can specify them on the comma
 | options.listeningPort | int | `9001` | Set the listening port of the capsule-proxy |
 | options.logLevel | string | `"4"` | Set the log verbosity of the capsule-proxy with a value from 1 to 10 |
 | options.oidcUsernameClaim | string | `"preferred_username"` | Specify if capsule-proxy will use SSL |
+| options.pprof | bool | `false` | Enable Pprof for profiling |
 | options.rolebindingsResyncPeriod | string | `"10h"` | Set the role bindings reflector resync period, a local cache to store mappings between users and their namespaces. [Use a lower value in case of flaky etcd server connections.](https://github.com/projectcapsule/capsule-proxy/issues/174) |
+| options.webhookPort | int | `9443` | Webhook port |
 
 ### Cert-Manager Parameters
 
@@ -202,6 +204,26 @@ You can manage the certificate with the help of [cert-manager](https://cert-mana
 | certManager.generateCertificates | bool | `false` | Set if the cert manager will generate SSL certificates (self-signed or CA-signed) |
 | certManager.issuer.kind | string | `"Issuer"` | Set if the cert manager will generate either self-signed or CA signed SSL certificates. Its value will be either Issuer or ClusterIssuer |
 | certManager.issuer.name | string | `""` | Set the name of the ClusterIssuer if issuer kind is ClusterIssuer and if cert manager will generate CA signed SSL certificates |
+
+### Webhook Parameters
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| webhooks.certificate.dnsNames | list | `[]` | Additional DNS Names to include in certificate |
+| webhooks.certificate.fields | object | `{"privateKey":{"rotationPolicy":"Always"}}` | Additional fields to include in certificate |
+| webhooks.certificate.ipAddresses | list | `[]` | Additional IP Addresses to include in certificate |
+| webhooks.certificate.uris | list | `[]` | Additional URIs to include in certificate |
+| webhooks.enabled | bool | `false` | Enable the usage of mutating and validating webhooks |
+| webhooks.service.caBundle | string | `""` | CABundle for the webhook service |
+| webhooks.service.name | string | `""` | Custom service name for the webhook service |
+| webhooks.service.namespace | string | `""` | Custom service namespace for the webhook service |
+| webhooks.service.port | string | `nil` | Custom service port for the webhook service |
+| webhooks.service.url | string | `""` | The URL where the capsule webhook services are running (Overwrites cluster scoped service definition) |
+| webhooks.watchdog.enabled | bool | `true` | Enable Watchdog Webhook |
+| webhooks.watchdog.failurePolicy | string | `"Ignore"` | Ignore failures from the webhook |
+| webhooks.watchdog.namespaceSelector | object | `{"matchExpressions":[{"key":"capsule.clastix.io/tenant","operator":"Exists"}]}` | Selects only namespaced items which are within a tenant |
+| webhooks.watchdog.rules | list | `[{"apiGroups":["*"],"apiVersions":["*"],"operations":["CREATE","UPDATE"],"resources":["*"],"scope":"Namespaced"}]` | Rules for which Objects and Actions this webhook should be called |
+| webhooks.watchdog.timeoutSeconds | string | `"3s"` | Timeout in seconds for mutating webhooks |
 
 ### Service Parameters
 

--- a/charts/capsule-proxy/README.md.gotmpl
+++ b/charts/capsule-proxy/README.md.gotmpl
@@ -101,7 +101,7 @@ If you only need to make minor customizations, you can specify them on the comma
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range .Values }}
-  {{- if not (or (hasPrefix "certManager" .Key)  (hasPrefix "global" .Key) (hasPrefix "options" .Key) (hasPrefix "service." .Key) (hasPrefix "ingress" .Key) (hasPrefix "autoscaling" .Key) (hasPrefix "serviceMonitor" .Key) )  }}
+  {{- if not (or (hasPrefix "certManager" .Key) (hasPrefix "webhooks" .Key) (hasPrefix "global" .Key) (hasPrefix "options" .Key) (hasPrefix "service." .Key) (hasPrefix "ingress" .Key) (hasPrefix "autoscaling" .Key) (hasPrefix "serviceMonitor" .Key) )  }}
 | {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
   {{- end }}
 {{- end }}
@@ -125,6 +125,16 @@ You can manage the certificate with the help of [cert-manager](https://cert-mana
 |-----|------|---------|-------------|
 {{- range .Values }}
   {{- if hasPrefix "certManager" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+### Webhook Parameters
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "webhooks." .Key }}
 | {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
   {{- end }}
 {{- end }}

--- a/charts/capsule-proxy/ci/webhook-values.yaml
+++ b/charts/capsule-proxy/ci/webhook-values.yaml
@@ -1,0 +1,2 @@
+webhooks:
+  enabled: true

--- a/charts/capsule-proxy/templates/_helpers.tpl
+++ b/charts/capsule-proxy/templates/_helpers.tpl
@@ -100,3 +100,31 @@ Render the CLI flag --host values for the self-signed certificate generator
 {{- $values = append $values $fullname -}}
 {{ join "," $values }}
 {{- end -}}
+
+
+
+{{/*
+Capsule Webhook service (Called with $.Path)
+
+*/}}
+{{- define "capsule-proxy.webhooks.service" -}}
+  {{- include "capsule-proxy.webhooks.cabundle" $.ctx | nindent 0 }}
+  {{- if $.ctx.Values.webhooks.service.url }}
+url: {{ printf "%s/%s" (trimSuffix "/" $.ctx.Values.webhooks.service.url ) (trimPrefix "/" (required "Path is required for the function" $.path)) }}
+  {{- else }}
+service:
+  name: {{ default (printf "%s-webhook-service" (include "capsule-proxy.fullname" $.ctx)) $.ctx.Values.webhooks.service.name }}
+  namespace: {{ default $.ctx.Release.Namespace $.ctx.Values.webhooks.service.namespace }}
+  port: {{ default 443 $.ctx.Values.webhooks.service.port }}
+  path: {{ required "Path is required for the function" $.path }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Capsule Webhook endpoint CA Bundle
+*/}}
+{{- define "capsule-proxy.webhooks.cabundle" -}}
+  {{- if $.Values.webhooks.service.caBundle -}}
+caBundle: {{ $.Values.webhooks.service.caBundle -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/capsule-proxy/templates/webhooks/certificate.yaml
+++ b/charts/capsule-proxy/templates/webhooks/certificate.yaml
@@ -1,0 +1,67 @@
+{{- if $.Values.webhooks.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "capsule-proxy.fullname" . }}-webhook-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "capsule-proxy.fullname" . }}-webhook-ca
+spec:
+  isCA: true
+  commonName: {{ include "capsule-proxy.fullname" . }}-webhook-ca
+  secretName: {{ include "capsule-proxy.fullname" . }}-webhook-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name:  {{ include "capsule-proxy.fullname" . }}-webhook-issuer
+    kind: Issuer
+    group: cert-manager.io
+---  
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "capsule-proxy.fullname" . }}-webhook
+spec:
+  ca:
+    secretName: {{ include "capsule-proxy.fullname" . }}-webhook-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "capsule-proxy.fullname" . }}-webhook-cert
+spec:
+  {{- with .Values.webhooks.certificate.fields }}
+    {{ toYaml . | nindent 2 }}
+  {{- end }}
+  dnsNames:
+  {{- range $dns := .Values.webhooks.certificate.dnsNames }}
+  - {{ $dns | quote }}
+  {{- end }}
+  - {{ include "capsule-proxy.fullname" . }}-webhook-service
+  - {{ include "capsule-proxy.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
+  {{- with .Values.webhooks.certificate.ipAddresses }}
+  ipAddresses:
+    {{- range $ip := . }}
+  - {{ $ip }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.webhooks.certificate.uris }}
+  uris:
+    {{- range $uri := . }}
+  - {{ $uri }}
+    {{- end }}
+  {{- end }}
+  issuerRef:
+    kind: "Issuer"
+    name: {{ include "capsule-proxy.fullname" . }}-webhook
+  secretName: {{ include "capsule-proxy.fullname" . }}-webhook-cert
+  subject:
+    organizations:
+      - projectcapsule.dev
+{{- end }}

--- a/charts/capsule-proxy/templates/webhooks/mutating.yaml
+++ b/charts/capsule-proxy/templates/webhooks/mutating.yaml
@@ -1,0 +1,31 @@
+{{- if $.Values.webhooks.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "capsule-proxy.fullname" . }}-webhook
+  labels:
+    {{- include "capsule-proxy.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "capsule-proxy.fullname" . }}-webhook-cert
+webhooks:
+  {{- with .Values.webhooks.watchdog }}
+    {{- if .enabled }}
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    {{- include "capsule-proxy.webhooks.service" (dict "path" "/mutate/watchdog" "ctx" $) | nindent 4 }}
+  failurePolicy: {{ .failurePolicy }}
+  name: watchdog.proxy.projectcapsule.dev
+  {{- with .rules }}
+  rules:
+    {{- toYaml .| nindent 4}} 
+  {{- end }}
+  {{- with .namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml .| nindent 4}} 
+  {{- end }}
+  sideEffects: None
+  timeoutSeconds: {{ $.Values.webhooks.mutatingWebhooksTimeoutSeconds }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/capsule-proxy/templates/webhooks/service.yaml
+++ b/charts/capsule-proxy/templates/webhooks/service.yaml
@@ -1,0 +1,18 @@
+{{- if $.Values.webhooks.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "capsule-proxy.fullname" . }}-webhook-service
+  labels:
+    {{- include "capsule-proxy.labels" . | nindent 4 }}
+spec:
+  ports:
+  - port: 443
+    name: https
+    protocol: TCP
+    targetPort: {{ .Values.options.webhookPort }}
+  selector:
+    {{- include "capsule-proxy.selectorLabels" . | nindent 4 }}
+  sessionAffinity: None
+  type: ClusterIP
+{{- end }}

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -17,9 +17,8 @@ global:
         pullPolicy: IfNotPresent
         # -- Set the image tag of the helm chart job
         tag: ""
-      # -- Annotations to add to the certgen job.
-      annotations:
-        "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+      # -- Annotations
+      annotations: {}
       # -- Set the restartPolicy
       restartPolicy: Never
       # -- Sets the ttl in seconds after a finished certgen job is deleted. Set to -1 to never delete.
@@ -273,6 +272,10 @@ options:
   clientConnectionQPS: 20
   # -- Burst to use for interacting with kubernetes API Server.
   clientConnectionBurst: 30
+  # -- Enable Pprof for profiling
+  pprof: false
+  # -- Webhook port
+  webhookPort: 9443
   # -- A list of extra arguments to add to the capsule-proxy.
   extraArgs: []
   # -"--feature-gates=ProxyClusterScoped=true"
@@ -306,6 +309,63 @@ certManager:
       privateKey:
         rotationPolicy: 'Always'
       # renewBefore: '24h'
+
+webhooks:
+  # -- Enable the usage of mutating and validating webhooks
+  enabled: false
+
+  # Configure custom webhook service
+  service:
+    # -- The URL where the capsule webhook services are running (Overwrites cluster scoped service definition)
+    url: ""
+    # -- CABundle for the webhook service
+    caBundle: ""
+    # -- Custom service name for the webhook service
+    name: ""
+    # -- Custom service namespace for the webhook service
+    namespace: ""
+    # -- Custom service port for the webhook service
+    port:
+
+  # Requires cert-manager
+  certificate:
+    # -- Additional DNS Names to include in certificate
+    dnsNames: []
+    # -- Additional IP Addresses to include in certificate
+    ipAddresses: []
+    # -- Additional URIs to include in certificate
+    uris: []
+    # -- Additional fields to include in certificate
+    fields:
+      privateKey:
+        rotationPolicy: 'Always'
+
+  watchdog:
+    # -- Enable Watchdog Webhook
+    enabled: true
+    # -- Timeout in seconds for mutating webhooks
+    timeoutSeconds: 3s
+    # We don't want to disturb operations if this webhook is not available
+    # watchdog will eventually add the label in the background
+    # -- Ignore failures from the webhook
+    failurePolicy: 'Ignore'
+    # -- Rules for which Objects and Actions this webhook should be called
+    rules:
+    - apiGroups:
+      - "*"
+      apiVersions:
+      - "*"
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - "*"
+      scope: "Namespaced"
+    # -- Selects only namespaced items which are within a tenant
+    namespaceSelector:
+      matchExpressions:
+        - key: capsule.clastix.io/tenant
+          operator: Exists
 
 # ServiceAccount
 serviceAccount:

--- a/internal/webhooks/watchdog.go
+++ b/internal/webhooks/watchdog.go
@@ -1,0 +1,76 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	capsulelabels "github.com/projectcapsule/capsule-proxy/internal/labels"
+)
+
+// MutatingWebhook handles mutating webhook requests.
+type WatchdogWebhook struct {
+	Decoder admission.Decoder
+	Client  client.Client
+	Log     logr.Logger
+}
+
+// Handle processes the admission request and adds a label if necessary.
+func (mw *WatchdogWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	mw.Log.V(7).Info("Received Request")
+	// Only consider namespaced objects
+	if req.Namespace == "" {
+		return admission.Allowed("not namespaced object")
+	}
+
+	// Decode the object
+	obj := &unstructured.Unstructured{}
+	if err := mw.Decoder.Decode(req, obj); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	tntList := capsulev1beta2.TenantList{}
+	if err := mw.Client.List(ctx, &tntList, client.MatchingFields{".status.namespaces": obj.GetNamespace()}); err != nil {
+		admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	if len(tntList.Items) == 0 {
+		return admission.Allowed("no tenant object")
+	}
+
+	tenant := tntList.Items[0].Name
+
+	mw.Log.V(7).Info("matching tenant", "name", tenant)
+
+	// Add the label if not present
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	if currentValue, exists := labels[capsulelabels.ManagedByCapsuleLabel]; exists && currentValue == tenant {
+		mw.Log.V(7).Info("label is already correctly set", capsulelabels.ManagedByCapsuleLabel, currentValue)
+
+		return admission.Allowed("tenant already set correctly")
+	}
+
+	// Add Label
+	labels[capsulelabels.ManagedByCapsuleLabel] = tntList.Items[0].Name
+	obj.SetLabels(labels)
+
+	mw.Log.V(7).Info("added label", capsulelabels.ManagedByCapsuleLabel, tntList.Items[0].Name)
+
+	// Marshal the object back to JSON
+	marshaledObj, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledObj)
+}


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule-proxy/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

We have some changes here:
- `pprof` should not be available always, only if specified via args. This is to prevent any leakage in production environments.
- `Watchdog`: only reconcile for `CREATE` and `UPDATE`, everything else does not matter for the labels
- `Webhooks`: Add Webhooks to the proxy. The watchdog webhook is very primitive. We have left a lot of configuration options for the webhook in the `values.yaml`. The webhooks are not enabled by default and the watchdog webhook is a failurePolicy of ignore by default. Updating should therefor not cause any interruptions

Using this Webhook will also resolve #530
