### PR TITLE
feat(controller): drop most legacy routes when ProxyClusterScoped is active

### DIFF
--- a/.github/configs/lintconf.yaml
+++ b/.github/configs/lintconf.yaml
@@ -6,6 +6,11 @@ ignore:
 rules:
   truthy:
     level: warning
+    allowed-values:
+    - "true"
+    - "false"
+    - "on"
+    - "off"
     check-keys: false
   braces:
     min-spaces-inside: 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,8 @@ repos:
     entry: make helm-lint
     language: system
     files: ^charts/
+  - id: golangci-lint
+    name: Execute golangci-lint
+    entry: make golint
+    language: system
+    files: \.go$

--- a/api/v1beta1/clusterresoure.go
+++ b/api/v1beta1/clusterresoure.go
@@ -22,8 +22,9 @@ type ClusterResource struct {
 	Resources []string `json:"resources"`
 
 	// Operations which can be executed on the selected resources.
-	// +kubebuilder:default={List}
-	Operations []ClusterResourceOperation `json:"operations"`
+	// Deprecated: For all registered Routes only LIST ang GET requests will intercepted
+	// Other permissions must be implemented via kubernetes native RBAC
+	Operations []ClusterResourceOperation `json:"operations,omitempty"`
 
 	// Select all cluster scoped resources with the given label selector.
 	// Defining a selector which does not match any resources is considered not selectable (eg. using operation NotExists).

--- a/charts/capsule-proxy/crds/capsule.clastix.io_globalproxysettings.yaml
+++ b/charts/capsule-proxy/crds/capsule.clastix.io_globalproxysettings.yaml
@@ -61,10 +61,10 @@ spec:
                               type: string
                             type: array
                           operations:
-                            default:
-                            - List
-                            description: Operations which can be executed on the selected
-                              resources.
+                            description: |-
+                              Operations which can be executed on the selected resources.
+                              Deprecated: For all registered Routes only LIST ang GET requests will intercepted
+                              Other permissions must be implemented via kubernetes native RBAC
                             items:
                               enum:
                               - List
@@ -128,7 +128,6 @@ spec:
                             x-kubernetes-map-type: atomic
                         required:
                         - apiGroups
-                        - operations
                         - resources
                         - selector
                         type: object

--- a/charts/capsule-proxy/crds/capsule.clastix.io_proxysettings.yaml
+++ b/charts/capsule-proxy/crds/capsule.clastix.io_proxysettings.yaml
@@ -59,10 +59,10 @@ spec:
                               type: string
                             type: array
                           operations:
-                            default:
-                            - List
-                            description: Operations which can be executed on the selected
-                              resources.
+                            description: |-
+                              Operations which can be executed on the selected resources.
+                              Deprecated: For all registered Routes only LIST ang GET requests will intercepted
+                              Other permissions must be implemented via kubernetes native RBAC
                             items:
                               enum:
                               - List
@@ -126,7 +126,6 @@ spec:
                             x-kubernetes-map-type: atomic
                         required:
                         - apiGroups
-                        - operations
                         - resources
                         - selector
                         type: object

--- a/e2e/namespace_test.go
+++ b/e2e/namespace_test.go
@@ -1,0 +1,123 @@
+package e2e_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
+)
+
+var _ = Describe("Namespaces", func() {
+	var aliceClient, bobClient *kubernetes.Clientset
+
+	// Create Global Proxy Settings
+	wind := &capsulev1beta2.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "wind",
+			Labels: e2eLabels(),
+		},
+		Spec: capsulev1beta2.TenantSpec{
+			Owners: capsulev1beta2.OwnerListSpec{
+				{
+					Name: "alice",
+					Kind: "User",
+				},
+			},
+		},
+	}
+
+	// Create Global Proxy Settings
+	solar := &capsulev1beta2.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "solar",
+			Labels: e2eLabels(),
+		},
+		Spec: capsulev1beta2.TenantSpec{
+			Owners: capsulev1beta2.OwnerListSpec{
+				{
+					Name: "bob",
+					Kind: "User",
+				},
+				{
+					Name: "alice",
+					Kind: "User",
+				},
+			},
+		},
+	}
+
+	BeforeEach(func() {
+		var err error
+
+		aliceClient, err = loadKubeConfig("alice")
+		Expect(err).ToNot(HaveOccurred())
+		bobClient, err = loadKubeConfig("bob")
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, tnt := range []*capsulev1beta2.Tenant{solar, wind} {
+			Eventually(func() error {
+				tnt.ResourceVersion = ""
+
+				return k8sClient.Create(context.TODO(), tnt)
+			}).Should(Succeed())
+		}
+	})
+
+	JustAfterEach(func() {
+		for _, tnt := range []*capsulev1beta2.Tenant{solar, wind} {
+			Expect(k8sClient.Delete(context.TODO(), tnt)).Should(Succeed())
+		}
+	})
+
+	It("Should correctly list", func() {
+		nsAlice1 := NewNamespace("")
+		nsAlice1.Labels = map[string]string{
+			"capsule.clastix.io/tenant": "wind",
+		}
+		NamespaceCreation(nsAlice1, wind.Spec.Owners[0], defaultTimeoutInterval).Should(Succeed())
+
+		nsAlice2 := NewNamespace("")
+		nsAlice2.Labels = map[string]string{
+			"capsule.clastix.io/tenant": "wind",
+		}
+		NamespaceCreation(nsAlice2, wind.Spec.Owners[0], defaultTimeoutInterval).Should(Succeed())
+
+		listNamespaces := func(clientset *kubernetes.Clientset) ([]string, error) {
+			ns, err := clientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				return nil, err
+			}
+			var nsNames []string
+			for _, name := range ns.Items {
+				nsNames = append(nsNames, name.Name)
+			}
+
+			return nsNames, nil
+		}
+
+		Eventually(func() ([]string, error) {
+			return listNamespaces(aliceClient)
+		}).Should(ConsistOf(nsAlice1.GetName(), nsAlice2.GetName()), "Alice should only have access to the expected namespaces, order does not matter")
+
+		nsBob1 := NewNamespace("")
+		nsBob1.Labels = map[string]string{
+			"capsule.clastix.io/tenant": "solar",
+		}
+		NamespaceCreation(nsBob1, solar.Spec.Owners[0], defaultTimeoutInterval).Should(Succeed())
+
+		nsBob2 := NewNamespace("")
+		nsBob2.Labels = map[string]string{
+			"capsule.clastix.io/tenant": "solar",
+		}
+		NamespaceCreation(nsBob2, solar.Spec.Owners[0], defaultTimeoutInterval).Should(Succeed())
+
+		Eventually(func() ([]string, error) {
+			return listNamespaces(bobClient)
+		}).Should(ConsistOf(nsBob1.GetName(), nsBob2.GetName()), "Alice should only have access to the expected namespaces, order does not matter")
+
+	})
+})

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -4,6 +4,7 @@ package e2e_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/utils/ptr"
@@ -36,6 +37,7 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).ToNot(BeNil())
 
 	Expect(v1beta1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(capsulev1beta2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 
 	ctrlClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())

--- a/internal/modules/utils/clusterscope.go
+++ b/internal/modules/utils/clusterscope.go
@@ -1,9 +1,7 @@
 package utils
 
 import (
-	"net/http"
 	"regexp"
-	"slices"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,17 +40,6 @@ func GetClusterScopeRequirements(gvk *schema.GroupVersionKind, proxyTenants []*t
 	}
 
 	return operations, requirements
-}
-
-func IsAllowed(operations []v1beta1.ClusterResourceOperation, request *http.Request) (ok bool) {
-	switch request.Method {
-	case http.MethodGet:
-		ok = slices.Contains(operations, v1beta1.ClusterResourceOperationList)
-	default:
-		break
-	}
-
-	return
 }
 
 func matchResource(gvk *schema.GroupVersionKind, cr v1beta1.ClusterResource) (match bool) {


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule-proxy/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

This PR improves the functionality of the GlobalProxySettings. The following changes are made:

1. If the flag is enabled, all routes, except namespaces and tenants, are handled by the new generic clusterScoped route. (Reported #668)
2. As filled in #681 we have a problem with request-type "smuggling". The PR already fixed it. With this PR i am dropping the operations field all together, as there will be **never** the use-case to handle any other operations than read operations. Other operations should directly hit the Kubernetes, not be rejected.

