### PR TITLE
chore: change loglevel of token so it isn't in stdout by default

### DIFF
--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -187,7 +187,7 @@ func (n *kubeFilter) handleRequest(request *http.Request, selector labels.Select
 	request.URL.RawQuery = q.Encode()
 
 	if len(n.BearerToken()) > 0 {
-		n.log.V(4).Info("Updating the token", "token", n.BearerToken())
+		n.log.V(10).Info("Updating the token", "token", n.BearerToken())
 		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", n.BearerToken()))
 	}
 }


### PR DESCRIPTION
Set loglevel of token to 10 (debug) so it isn't in the stdout by default. Default loglevel is 4.