### PR TITLE
feat: add toggle for securityContext and PodSecurityContext

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -33,7 +33,5 @@ annotations:
     - name: Documentation
       url: https://projectcapsule.dev/
   artifacthub.io/changes: |
-    - kind: changed
-      description: cert-job image from docker.io/jettech/kube-webhook-certgen to registry.k8s.io/ingress-nginx/kube-webhook-certgen (.Values.global.jobs.certs.image)
     - kind: added
-      description: Webhook values
+      description: added toggles for podSecurityContexts and securityContexts

--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -97,11 +97,11 @@ If you only need to make minor customizations, you can specify them on the comma
 | global.jobs.certs.image.repository | string | `"ingress-nginx/kube-webhook-certgen"` | Set the image repository of the post install certgen job |
 | global.jobs.certs.image.tag | string | `"v1.6.0"` | Set the image tag of the post install certgen job |
 | global.jobs.certs.nodeSelector | object | `{}` | Set the node selector |
-| global.jobs.certs.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the job pods. |
+| global.jobs.certs.podSecurityContext | object | `{"enabled":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the job pods. |
 | global.jobs.certs.priorityClassName | string | `""` | Set a pod priorityClassName |
 | global.jobs.certs.resources | object | `{}` | Job resources |
 | global.jobs.certs.restartPolicy | string | `"Never"` | Set the restartPolicy |
-| global.jobs.certs.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Security context for the job containers. |
+| global.jobs.certs.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"readOnlyRootFilesystem":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Security context for the job containers. |
 | global.jobs.certs.tolerations | list | `[]` | Set list of tolerations |
 | global.jobs.certs.topologySpreadConstraints | list | `[]` | Set Topology Spread Constraints |
 | global.jobs.certs.ttlSecondsAfterFinished | int | `60` | Sets the ttl in seconds after a finished certgen job is deleted. Set to -1 to never delete. |
@@ -112,11 +112,11 @@ If you only need to make minor customizations, you can specify them on the comma
 | global.jobs.kubectl.image.repository | string | `"clastix/kubectl"` | Set the image repository of the helm chart job |
 | global.jobs.kubectl.image.tag | string | `""` | Set the image tag of the helm chart job |
 | global.jobs.kubectl.nodeSelector | object | `{}` | Set the node selector |
-| global.jobs.kubectl.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the job pods. |
+| global.jobs.kubectl.podSecurityContext | object | `{"enabled":false,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the job pods. |
 | global.jobs.kubectl.priorityClassName | string | `""` | Set a pod priorityClassName |
 | global.jobs.kubectl.resources | object | `{}` | Job resources |
 | global.jobs.kubectl.restartPolicy | string | `"Never"` | Set the restartPolicy |
-| global.jobs.kubectl.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Security context for the job containers. |
+| global.jobs.kubectl.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":false,"readOnlyRootFilesystem":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Security context for the job containers. |
 | global.jobs.kubectl.tolerations | list | `[]` | Set list of tolerations |
 | global.jobs.kubectl.topologySpreadConstraints | list | `[]` | Set Topology Spread Constraints |
 | global.jobs.kubectl.ttlSecondsAfterFinished | int | `60` | Sets the ttl in seconds after a finished certgen job is deleted. Set to -1 to never delete. |
@@ -145,7 +145,7 @@ If you only need to make minor customizations, you can specify them on the comma
 | nodeSelector | object | `{}` | Set the node selector for the capsule-proxy pod. |
 | podAnnotations | object | `{}` | Annotations to add to the capsule-proxy pod. |
 | podLabels | object | `{}` | Labels to add to the capsule-proxy pod. |
-| podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the capsule-proxy pod. |
+| podSecurityContext | object | `{"enabled":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the capsule-proxy pod. |
 | priorityClassName | string | `""` | Specifies PriorityClass of the capsule-proxy pod. |
 | rbac.clusterRole | string | `"cluster-admin"` | Controller ClusterRole |
 | rbac.enabled | bool | `true` | Enable Creation of ClusterRoles |
@@ -156,7 +156,7 @@ If you only need to make minor customizations, you can specify them on the comma
 | resources.requests.cpu | string | `"200m"` | Set the CPU limits assigned to the controller. |
 | resources.requests.memory | string | `"128Mi"` | Set the memory limits assigned to the controller. |
 | restartPolicy | string | `"Always"` | Set the restartPolicy for the capsule-proxy pod. |
-| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Security context for the capsule-proxy container. |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"readOnlyRootFilesystem":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Security context for the capsule-proxy container. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `capsule-proxy` | The name of the service account to use. If not set and `serviceAccount.create=true`, a name is generated using the fullname template |

--- a/charts/capsule-proxy/templates/_pod.tpl
+++ b/charts/capsule-proxy/templates/_pod.tpl
@@ -21,8 +21,9 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   serviceAccountName: {{ include "capsule-proxy.serviceAccountName" . }}
-  securityContext:
-    {{- toYaml .Values.podSecurityContext | nindent 4 }}
+  {{- if .Values.podSecurityContext.enabled }}
+  securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 4 }}
+  {{- end }}
   priorityClassName: {{ .Values.priorityClassName }}
   volumes:
   {{- with .Values.volumes }}
@@ -46,8 +47,9 @@ spec:
   {{- end }}
   containers:
   - name: {{ .Chart.Name }}
-    securityContext:
-      {{- toYaml .Values.securityContext | nindent 6 }}
+    {{- if .Values.securityContext.enabled }}
+    securityContext: {{- omit .Values.securityContext "enabled" | toYaml | nindent 6 }}
+    {{- end }}
     image: {{ include "capsule-proxy.fullyQualifiedDockerImage" . }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
     args:

--- a/charts/capsule-proxy/templates/certgen-job.yaml
+++ b/charts/capsule-proxy/templates/certgen-job.yaml
@@ -21,9 +21,8 @@ spec:
         {{- include "capsule-proxy.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: {{ $Values.restartPolicy }}
-      {{- with $Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
+      {{- if $Values.podSecurityContext.enabled }}
+      securityContext: {{- omit $Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- with $Values.nodeSelector }}
       nodeSelector:
@@ -64,9 +63,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- with $Values.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
+        {{- if $Values.securityContext.enabled }}
+        securityContext: {{- omit $Values.securityContext "enabled" | toYaml | nindent 10 }}
         {{- end }}
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/capsule-proxy/templates/crd-lifecycle/job.yaml
+++ b/charts/capsule-proxy/templates/crd-lifecycle/job.yaml
@@ -20,9 +20,8 @@ spec:
         {{- include "capsule-proxy.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: {{ $.Values.global.jobs.kubectl.restartPolicy }}
-      {{- with $.Values.global.jobs.kubectl.podSecurityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
+      {{- if $.Values.global.jobs.kubectl.podSecurityContext.enabled }}
+      securityContext: {{- omit $.Values.global.jobs.kubectl.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.global.jobs.kubectl.nodeSelector }}
       nodeSelector:
@@ -52,9 +51,8 @@ spec:
       - name: crds-hook
         image: {{ include "capsule-proxy.kubectlFullyQualifiedDockerImage" . }}
         imagePullPolicy: {{ .Values.global.jobs.kubectl.image.pullPolicy }}
-        {{- with $.Values.global.jobs.kubectl.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
+        {{- if .Values.global.jobs.kubectl.securityContext.enabled }}
+        securityContext: {{- omit .Values.global.jobs.kubectl.securityContext "enabled" | toYaml | nindent 10 }}
         {{- end }}
         command:
         - sh

--- a/charts/capsule-proxy/values.schema.json
+++ b/charts/capsule-proxy/values.schema.json
@@ -200,6 +200,9 @@
                                     "description": "Security context for the job pods.",
                                     "type": "object",
                                     "properties": {
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
                                         "seccompProfile": {
                                             "type": "object",
                                             "properties": {
@@ -239,6 +242,9 @@
                                                     }
                                                 }
                                             }
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
                                         },
                                         "readOnlyRootFilesystem": {
                                             "type": "boolean"
@@ -308,6 +314,9 @@
                                     "description": "Security context for the job pods.",
                                     "type": "object",
                                     "properties": {
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
                                         "seccompProfile": {
                                             "type": "object",
                                             "properties": {
@@ -347,6 +356,9 @@
                                                     }
                                                 }
                                             }
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
                                         },
                                         "readOnlyRootFilesystem": {
                                             "type": "boolean"
@@ -596,6 +608,9 @@
             "description": "Security context for the capsule-proxy pod.",
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "seccompProfile": {
                     "type": "object",
                     "properties": {
@@ -705,6 +720,9 @@
                             }
                         }
                     }
+                },
+                "enabled": {
+                    "type": "boolean"
                 },
                 "readOnlyRootFilesystem": {
                     "type": "boolean"

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -25,10 +25,12 @@ global:
       ttlSecondsAfterFinished: 60
       # -- Security context for the job pods.
       podSecurityContext:
+        enabled: false
         seccompProfile:
           type: "RuntimeDefault"
       # -- Security context for the job containers.
       securityContext:
+        enabled: false
         allowPrivilegeEscalation: false
         capabilities:
           drop:
@@ -69,10 +71,12 @@ global:
       ttlSecondsAfterFinished: 60
       # -- Security context for the job pods.
       podSecurityContext:
+        enabled: true
         seccompProfile:
           type: "RuntimeDefault"
       # -- Security context for the job containers.
       securityContext:
+        enabled: true
         allowPrivilegeEscalation: false
         capabilities:
           drop:
@@ -205,10 +209,12 @@ livenessProbe:
 priorityClassName: ""
 # -- Security context for the capsule-proxy pod.
 podSecurityContext:
+  enabled: true
   seccompProfile:
     type: "RuntimeDefault"
 # -- Security context for the capsule-proxy container.
 securityContext:
+  enabled: true
   allowPrivilegeEscalation: false
   capabilities:
     drop:


### PR DESCRIPTION
Added toggles for enabling/disabling securityContext and PodSecurityContext. If you have other security measurements in place (for example Openshift SCC's), the default SecurityContexts are not needed. In the past, we provided an empty string for the securityContext, which always worked. But suddenly, ArgoCD does not accept this anymore. So, adding a toggle for this. 

(This is the same change as added in the [sops-operator](https://github.com/peak-scale/sops-operator/pull/90) and [capsule](https://github.com/projectcapsule/capsule/pull/1546))