### PR TITLE
fix(GlobalProxySettings): allow multiple subjects in rules

### DIFF
--- a/internal/tenant/proxytenant.go
+++ b/internal/tenant/proxytenant.go
@@ -65,7 +65,7 @@ func NewClusterProxy(ownerName string, ownerKind capsulev1beta2.OwnerKind, owner
 	for _, global := range owners {
 		for _, subject := range global.Subjects {
 			if subject.Name == ownerName && subject.Kind == ownerKind {
-				tenantClusterResources = global.ClusterResources
+				tenantClusterResources = append(tenantClusterResources, global.ClusterResources...)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes a bug where only the last entry of multiple subjects in rules of a GlobalProxySettings was displayed to a capsule tenant owner.

Multiple **GlobalProxySettings** - works:
```
apiVersion: capsule.clastix.io/v1beta1
kind: GlobalProxySettings
metadata:
  name: crd-foo
spec:
  rules:
  - clusterResources:
    - apiGroups:
      - apiextensions.k8s.io/v1
      operations:
      - List
      resources:
      - customresourcedefinitions
      selector:
        matchExpressions:
        - key: app
          operator: In
          values:
          - foo
    subjects:
    - kind: User
      name: foo@example.com
---
apiVersion: capsule.clastix.io/v1beta1
kind: GlobalProxySettings
metadata:
  name: crd-bar
spec:
  rules:
  - clusterResources:
    - apiGroups:
      - apiextensions.k8s.io/v1
      operations:
      - List
      resources:
      - customresourcedefinitions
      selector:
        matchExpressions:
        - key: app
          operator: In
          values:
          - bar
    subjects:
    - kind: User
      name: foo@example.com
```

Multiple **operations** - works:
```
apiVersion: capsule.clastix.io/v1beta1
kind: GlobalProxySettings
metadata:
  name: crd-foo
spec:
  rules:
  - clusterResources:
    - operations:
      - List
      apiGroups:
      - apiextensions.k8s.io/v1
      resources:
      - customresourcedefinitions
      selector:
        matchExpressions:
        - key: app
          operator: In
          values:
          - foo
    - operations:
      - List
      apiGroups:
      - apiextensions.k8s.io/v1
      resources:
      - customresourcedefinitions
      selector:
        matchExpressions:
        - key: app
          operator: In
          values:
          - bar
    subjects:
    - kind: User
      name: foo@example.com
```

Multiple **subjects** - didn't work before
```
apiVersion: capsule.clastix.io/v1beta1
kind: GlobalProxySettings
metadata:
  name: crd-foo
spec:
  rules:
  - subjects:
    - kind: User
      name: foo@example.com
    clusterResources:
    - apiGroups:
      - apiextensions.k8s.io/v1
      operations:
      - List
      resources:
      - customresourcedefinitions
      selector:
        matchExpressions:
        - key: app
          operator: In
          values:
          - foo
  - subjects:
    - kind: User
      name: foo@example.com
    clusterResources:
    - apiGroups:
      - apiextensions.k8s.io/v1
      operations:
      - List
      resources:
      - customresourcedefinitions
      selector:
        matchExpressions:
        - key: app
          operator: In
          values:
          - bar
```