### PR TITLE
feat(charts/capsule-proxy): added extra manifests in values file

### DIFF
--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -136,6 +136,7 @@ If you only need to make minor customizations, you can specify them on the comma
 | daemonset.hostNetwork | bool | `false` | Use the host network namespace for capsule-proxy pod. |
 | daemonset.hostPort | bool | `false` | Binding the capsule-proxy listening port to the host port. |
 | env | list | `[]` | Additional environment variables |
+| extraManifests | list | `[]` | Array of additional resources to be created alongside Capsule helm chart |
 | hostNetwork | bool | `false` | When deployed as DaemonSet use |
 | image.pullPolicy | string | `"IfNotPresent"` | Set the image pull policy. |
 | image.registry | string | `"ghcr.io"` | Set the image registry for capsule-proxy |

--- a/charts/capsule-proxy/ci/extra-values.yaml
+++ b/charts/capsule-proxy/ci/extra-values.yaml
@@ -1,0 +1,8 @@
+# -- Array of additional resources to be created alongside Capsule helm chart
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: random-config
+    data:
+      random-value: "{{ randAlphaNum 16 }}"

--- a/charts/capsule-proxy/templates/extra-manifests.yaml
+++ b/charts/capsule-proxy/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/capsule-proxy/values.schema.json
+++ b/charts/capsule-proxy/values.schema.json
@@ -154,6 +154,10 @@
             "description": "Additional environment variables",
             "type": "array"
         },
+        "extraManifests": {
+            "description": "Array of additional resources to be created alongside Capsule helm chart",
+            "type": "array"
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -329,6 +329,15 @@ certManager:
         rotationPolicy: 'Always'
       # renewBefore: '24h'
 
+# -- Array of additional resources to be created alongside Capsule helm chart
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-configmap
+  #   data:
+  #     key: value
+
 webhooks:
   # -- Enable the usage of mutating and validating webhooks
   enabled: false


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule-proxy/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->

This will give the possibility to add extra kubernetes resources/objects such as (Global)ProxySettings, KEDA ScaledObject, configMaps.
Things that are not part of the chart itself but part of/related to Capsule proxy.
