### PR TITLE
fix(helm): add flag 'enable-reflector' to pod template

### DIFF
--- a/charts/capsule-proxy/templates/_pod.tpl
+++ b/charts/capsule-proxy/templates/_pod.tpl
@@ -61,6 +61,7 @@ spec:
     - --zap-log-level={{ .Values.options.logLevel }}
     - --enable-ssl={{ .Values.options.enableSSL }}
     - --oidc-username-claim={{ .Values.options.oidcUsernameClaim }}
+    - --enable-reflector={{ .Values.options.roleBindingReflector }}
     - --rolebindings-resync-period={{ .Values.options.rolebindingsResyncPeriod }}
     - --disable-caching={{ .Values.options.disableCaching }}
     - --auth-preferred-types={{ .Values.options.authPreferredTypes }}


### PR DESCRIPTION
<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule-proxy/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->
This PR add the flag `enable-reflector` in the pod template to activate the option `roleBindingReflector` from the chart Helm. See issue [#1838](https://github.com/projectcapsule/capsule/issues/1838) from the capsule repo.

The issue has been recreated in the correct repository see #947 