### PR TITLE
fix: invalid HTTP status code on error

### DIFF
--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -518,6 +518,9 @@ func (n *kubeFilter) registerModules(ctx context.Context, root *mux.Router) {
 			case err != nil:
 				var t moderrors.Error
 				if errors.As(err, &t) {
+					if t.Status().Code > 0 {
+						writer.WriteHeader(int(t.Status().Code))
+					}
 					writer.Header().Set("Content-Type", "application/json")
 
 					b, _ := json.Marshal(t.Status())


### PR DESCRIPTION
Ensure the original status code is sent back to the client in case of error.

Previously, we would return a 200 (by default), which could induce the client to strange behaviour.

For example, we have a go client that performs a get-and-update pattern to apply manifests. In case of error getting the resource, it would get back a 200, and take the body as the "existing" resource (which is wrong), and then patch it locally, and update it. The server would then refuse the request with a 404, and the client will fail, saying it can't create a new resource because it doesn't exist...
