### PR TITLE
feat: cert-watcher to handle hot reload

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,6 @@ golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
-golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
 golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/component-base/featuregate"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/projectcapsule/capsule-proxy/api/v1beta1"
@@ -180,6 +181,25 @@ func (n *kubeFilter) Start(ctx context.Context) error {
 	root.PathPrefix("/").HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		n.impersonateHandler(writer, request)
 	})
+	// cert-watcher integration:
+	// extracting the GetCertificate function for hot reload upon certificate update.
+	// This will be used only if the proxy is set to bare TLS mode.
+	var getCertificateFn func(*tls.ClientHelloInfo) (*tls.Certificate, error)
+
+	if n.serverOptions.IsListeningTLS() {
+		watcher, watcherErr := certwatcher.New(n.serverOptions.TLSCertificatePath(), n.serverOptions.TLSCertificateKeyPath())
+		if watcherErr != nil {
+			return fmt.Errorf("cannot create certificate watcher: %w", watcherErr)
+		}
+
+		getCertificateFn = watcher.GetCertificate
+
+		go func() {
+			if startErr := watcher.Start(ctx); startErr != nil {
+				panic(fmt.Errorf("cannot start certificate watcher: %w", startErr))
+			}
+		}()
+	}
 
 	var srv *http.Server
 
@@ -190,8 +210,9 @@ func (n *kubeFilter) Start(ctx context.Context) error {
 
 		if n.serverOptions.IsListeningTLS() {
 			tlsConfig := &tls.Config{
-				MinVersion: tls.VersionTLS12,
-				ClientCAs:  n.serverOptions.GetCertificateAuthorityPool(),
+				ClientCAs:      n.serverOptions.GetCertificateAuthorityPool(),
+				GetCertificate: getCertificateFn,
+				MinVersion:     tls.VersionTLS12,
 			}
 
 			for _, authType := range n.authTypes {
@@ -208,13 +229,20 @@ func (n *kubeFilter) Start(ctx context.Context) error {
 				TLSConfig:         tlsConfig,
 				ReadHeaderTimeout: 5 * time.Second,
 			}
-			err = srv.ListenAndServeTLS(n.serverOptions.TLSCertificatePath(), n.serverOptions.TLSCertificateKeyPath())
+
+			ln, lnErr := tls.Listen("tcp", addr, tlsConfig)
+			if lnErr != nil {
+				panic("cannot create listener: " + lnErr.Error())
+			}
+
+			err = srv.Serve(ln)
 		} else {
 			srv = &http.Server{
 				Handler:           r,
 				Addr:              addr,
 				ReadHeaderTimeout: 5 * time.Second,
 			}
+
 			err = srv.ListenAndServe()
 		}
 


### PR DESCRIPTION
Supporting via `sigs.k8s.io/controller-runtime/pkg/certwatcher` the hot reload of Server's certificate.

Tested locally by mounting `mkcert` certificates.

```
$: curl -v --capath /tmp/k8s-webhook-server/serving-certs/ca.crt https://127.0.0.1:9001
* Server certificate:
*  subject: O=mkcert development certificate; OU=prometherion@akephalos
*  start date: Mar 11 10:37:55 2026 GMT
*  expire date: Jun 11 09:37:55 2028 GMT
*  subjectAltName: host "127.0.0.1" matched cert's IP address!
*  issuer: O=mkcert development CA; OU=prometherion@akephalos; CN=mkcert prometherion@akephalos
*  SSL certificate verify ok.
```

Also from Capsule Proxy logs:
```
{"level":"Level(-7)","ts":"2026-03-11T11:44:05.099+0100","logger":"controller-runtime.certwatcher","msg":"certificate already cached","cert":"/tmp/k8s-webhook-server/serving-certs/tls.crt","key":"/tmp/k8s-webhook-server/serving-certs/tls.key"}
```

Updating new certificates using `mkcert`, Capsule Proxy is being notified:
```
{"level":"debug","ts":"2026-03-11T11:44:42.360+0100","logger":"controller-runtime.certwatcher","msg":"certificate event","cert":"/tmp/k8s-webhook-server/serving-certs/tls.crt","key":"/tmp/k8s-webhook-server/serving-certs/tls.key","event":"WRITE         \"/tmp/k8s-webhook-server/serving-certs/tls.crt\""}
{"level":"error","ts":"2026-03-11T11:44:42.361+0100","logger":"controller-runtime.certwatcher","msg":"error re-reading certificate","cert":"/tmp/k8s-webhook-server/serving-certs/tls.crt","key":"/tmp/k8s-webhook-server/serving-certs/tls.key","error":"tls: private key does not match public key","stacktrace":"sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).handleEvent\n\t/home/prometherion/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/certwatcher/certwatcher.go:243\nsigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).Watch\n\t/home/prometherion/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/certwatcher/certwatcher.go:159"}
{"level":"debug","ts":"2026-03-11T11:44:43.486+0100","logger":"controller-runtime.certwatcher","msg":"certificate event","cert":"/tmp/k8s-webhook-server/serving-certs/tls.crt","key":"/tmp/k8s-webhook-server/serving-certs/tls.key","event":"WRITE         \"/tmp/k8s-webhook-server/serving-certs/tls.key\""}
{"level":"info","ts":"2026-03-11T11:44:43.486+0100","logger":"controller-runtime.certwatcher","msg":"Updated current TLS certificate","cert":"/tmp/k8s-webhook-server/serving-certs/tls.crt","key":"/tmp/k8s-webhook-server/serving-certs/tls.key"}
{"level":"Level(-7)","ts":"2026-03-11T11:44:45.099+0100","logger":"controller-runtime.certwatcher","msg":"certificate already cached","cert":"/tmp/k8s-webhook-server/serving-certs/tls.crt","key":"/tmp/k8s-webhook-server/serving-certs/tls.key"}
```

Checking if certificates are now updated:
```
$: curl -v --capath /tmp/k8s-webhook-server/serving-certs/ca.crt https://127.0.0.1:9001
* Server certificate:
*  subject: O=mkcert development certificate; OU=prometherion@akephalos
*  start date: Mar 11 10:44:41 2026 GMT
*  expire date: Jun 11 09:44:41 2028 GMT
*  subjectAltName: host "127.0.0.1" matched cert's IP address!
*  issuer: O=mkcert development CA; OU=prometherion@akephalos; CN=mkcert prometherion@akephalos
*  SSL certificate verify ok.
```

The expiration date has been updated: it was `Jun 11 09:37:55 2028 GMT`, now `Jun 11 09:44:41 2028 GMT`.