### PR TITLE
fix: allow secret permission if self signed cerfificates are generated

### DIFF
--- a/charts/capsule-proxy/templates/rbac.yaml
+++ b/charts/capsule-proxy/templates/rbac.yaml
@@ -11,7 +11,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
   - apiGroups: [""]
-    resources: ["configmaps", "endpoints"]
+    resources: ["configmaps", "endpoints"{{ if and .Values.options.enableSSL .Values.options.generateCertificates }}, "secrets"{{ end }}]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
When no cert manager is available and self signed certificates should be created, the service account needs permission to manipulate the secret