### PR TITLE
fix: return early after error in impersonateHandler

### DIFF
--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -436,6 +436,8 @@ func (n *kubeFilter) impersonateHandler(writer http.ResponseWriter, request *htt
 		} else {
 			server.HandleError(writer, err, msg)
 		}
+
+		return
 	}
 
 	n.log.V(4).Info("impersonating for the current request", "username", username, "groups", groups, "uri", request.URL.Path)


### PR DESCRIPTION
When the user or group lookup fails, the handler was logging/responding the error but then falling through to the impersonation logic. Adding an early return prevents the request from continuing with an empty or invalid identity.

<!--
Read the contribution guidelines before creating a pull request.

https://github.com/projectcapsule/capsule-proxy/blob/main/CONTRIBUTING.md

Thanks for spending some time for improving and fixing Capsule!
-->
