### PR TITLE
ci: add fossa project.team name

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,4 @@
+version: 3
+
+project:
+  team: Capsule


### PR DESCRIPTION
This pull request makes a minor configuration update by adding a `team` assignment to the `.fossa.yml` file. This change helps clarify project ownership for the FOSSA tool.