### PR TITLE
fix: serve the OAuth discovery document without authentication

### DIFF
--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -190,6 +190,14 @@ func (n *kubeFilter) Start(ctx context.Context) error {
 		_, _ = writer.Write([]byte("ok"))
 	})
 
+	// Served without authentication: clients retrieve this document before
+	// they have any credentials (e.g. oc login --web). The upstream API
+	// server answers the path anonymously. Trusted-source restrictions and
+	// GET/HEAD methods still apply.
+	oauthMetadata := r.Path("/.well-known/oauth-authorization-server").Subrouter()
+	oauthMetadata.Use(middleware.RequireTrustedSourceMiddleware(n.log, n.trustedProxyCIDRs))
+	oauthMetadata.Methods(http.MethodGet, http.MethodHead).Handler(n.reverseProxy)
+
 	root := r.PathPrefix("").Subrouter()
 	n.registerModules(ctx, root)
 	root.Use(


### PR DESCRIPTION
`oc login <proxy-host> --web` (and any client using the OAuth authorization code flow) requests `/.well-known/oauth-authorization-server` from the API endpoint before it has any credentials. The proxy requires authentication to resolve the user on every request, so this request was rejected and the login aborted before the browser flow could even start (oc then fails with a confusing `unsupported protocol scheme ""`).

The upstream API server already serves this document for anonymous requests, so the proxy can simply forward it. This registers the path on the top-level router next to `/_healthz`, outside the authenticated subrouter, and hands it to the reverse proxy.

Validated against an OpenShift cluster (Hypershift-hosted control plane, Kubernetes 1.33):

- `GET /.well-known/oauth-authorization-server` without credentials: `200` with the cluster OAuth metadata, identical to the API server response
- `GET /version` and `GET /api/v1/namespaces` without credentials: still `403`, the authentication requirement is unchanged for everything else
- authenticated tenant-scoped listing through the proxy: unchanged

With this in place `oc login <proxy-host> --web` completes against capsule-proxy on OpenShift: discovery succeeds, the browser flow runs against the cluster OAuth server, and the token exchange and API traffic go through the proxy as usual.

Unrelated but worth flagging while testing: `main` currently panics on startup when no bearer token is configured (`bearerExpirationTime` dereferences the nil token returned by the jwt v5 `ParseUnverified` on empty input, `webserver.go:826-827`). I carried a local nil guard to run the validation above; happy to send that as a separate PR if useful.